### PR TITLE
Expand SOURCEMAP_INDEX with detailed interaction and chunk loading flows

### DIFF
--- a/.claude/SOURCEMAP_INDEX.md
+++ b/.claude/SOURCEMAP_INDEX.md
@@ -149,18 +149,71 @@ Complete navigation guide for the Perovskite voxel game engine codebase. Four cr
 
 ### Player Interaction (dig/place/tap)
 ```
-Client gRPC request
-  → network_server::grpc_service
-    → GameState event handler
-      → Item dig_handler (if present)
-        → Block interaction handler
-          → game_map.set_block() / dig_block()
-            → Light propagation
-              → Database write (on chunk flush)
-      → Inventory update
-  → Network response: updated chunk + item stack
-    → client_state cache update
-      → vulkan re-mesh affected chunks
+[Client — client_workers.rs OutboundContext]
+  Input event (mouse click) → GameAction::Dig / Tap / Place
+  → handle_game_action() first sends a position update (with pacing),
+    then sends StreamToServer::Dig / Tap / Place
+
+[Server — client_context.rs InboundWorker]
+  Receives StreamToServer message
+  → Permission check (DIG_PLACE or TAP_INTERACT)
+  → Dispatch to handler (all run via block_in_place on Tokio thread):
+
+  DIG / TAP (block target):
+    run_map_handlers()
+      → inventory_manager().mutate_inventory_atomically(player main inventory)
+          [holds inventory mutex for entire interaction]
+          → Look up ItemStack in selected slot
+          → Resolve item handler:
+              item.dig_handler / tap_handler  (if item has one registered)
+              OR items::default_dig_handler / default_tap_handler (fallback)
+          → Item handler calls game_map().dig_block() / tap_block()
+              → run_block_interaction(coord, ...)
+                  Phase 1 — inline handler (inside mutate_block_atomically,
+                            holds chunk shard lock):
+                    block.dig_handler_inline / tap_handler_inline (if present)
+                    InlineContext: can mutate block id + ExtendedData in place
+                    Lighting updated after mutation, writeback enqueued
+                  Phase 2 — full handler (chunk lock released first,
+                            avoids deadlock):
+                    block.dig_handler_full / tap_handler_full (if present)
+                    HandlerContext: full GameState access, can call set_block,
+                    spawn timers, send chat, etc.
+                  Results from both phases coalesced (CoalesceResult)
+          → ItemInteractionResult: updated_stack + obtained_items
+          → Write updated_stack back to inventory slot
+          → Insert obtained_items into player inventory (drop if full)
+          [inventory mutex released]
+
+  PLACE (block/entity target):
+    handle_place()
+      → inventory_manager().mutate_inventory_atomically(player main inventory)
+          → Look up ItemStack in selected slot
+          → item.place_on_block_handler (if present; no default fallback)
+          → PlaceHandler calls game_map().set_block() internally
+          → Write updated_stack back to slot, insert obtained_items
+
+  Entity targets: same structure but use dig_entity_handler /
+    tap_entity_handler / place_on_entity_handler + entity coordinates
+
+[Broadcast — game_map → BlockEventSender per connected client]
+  set_block / dig_block emit UpdateBroadcast::Block on a broadcast channel
+  → BlockEventSender.block_sender_loop() receives update
+      → Filters to chunks this client has subscribed to (ChunkTracker)
+      → Coalesces up to MAX_UPDATE_OUTGOING_BATCH_SIZE block updates
+        (drains channel with up to 10ms wait for batching)
+      → Sends StreamToClient::MapDeltaUpdate { updates: Vec<MapDeltaUpdate> }
+  Lagged client: resyncs by re-sending full chunk data (aimd.decrease_to_floor())
+
+[Ack]
+  Server sends StreamToClient::HandledSequence(sequence) after handling
+  → Client uses RTT for pacing, unblocks next position update
+
+[Client — client_workers.rs InboundContext]
+  Receives MapDeltaUpdate
+  → handle_map_delta_update() → client_state.chunks.update_block()
+    → Enqueues affected chunks for re-mesh (NeighborPropagator → MeshWorker)
+      → Vulkan renders updated geometry next frame
 ```
 
 ### Chunk Loading

--- a/.claude/SOURCEMAP_INDEX.md
+++ b/.claude/SOURCEMAP_INDEX.md
@@ -165,17 +165,57 @@ Client gRPC request
 
 ### Chunk Loading
 ```
-Client approaches chunk
-  → gRPC request: load_chunk(coordinate)
-    → ServerGameMap.get_chunk_data()
-      → Database lookup
-        → Deserialize blocks + extended data
-        → Lighting data
-      → Protobuf encode
-  → Network response: MapChunk
-    → client_state cache
-      → vulkan generates mesh
-        → Render next frame
+[Client OutboundContext — client_workers.rs]
+  Timer fires (~every frame) or game action triggered
+  → send_position_update(last_position)
+    → Attach ClientPacing { pending_chunks, distance_limit } to the message
+        pending_chunks = sum of all MeshWorker queue lengths (backpressure signal)
+        distance_limit = current render distance setting
+    → Send StreamToServer::PositionUpdate via bidirectional gRPC stream
+    Note: if previous position update has not been acked yet, the update is
+    withheld (avoids flooding the server with unacknowledged positions)
+
+[Server InboundWorker — client_context.rs]
+  Receives StreamToServer::PositionUpdate
+  → Reads pacing.pending_chunks and pacing.distance_limit from the message
+  → Adjusts chunk_aimd (AIMD controller, shared with MapChunkSenders):
+      - network backlogged (RTT > 250ms):  aimd.decrease() twice
+      - pending_chunks > 1024:             aimd.decrease()
+      - pending_chunks < 256:              aimd.increase()
+      - block event lagged:                aimd.decrease_to_floor()
+    AIMD parameters: additive_increase=64, multiplicative_decrease=0.5,
+    initial=128, max=4096 chunks per position update
+  → Publishes PositionAndPacing { kinematics, chunks_to_send=aimd.get(),
+      client_requested_render_distance } on a watch channel
+
+[Server MapChunkSender — client_context.rs]  (two instances, sharded by parity)
+  Watches the PositionAndPacing watch channel for changes
+  → send_chunks_for_position_update(update)
+    → Phase 1: Unsubscribe out-of-range chunks
+        → Sends StreamToClient::MapChunkUnsubscribe to client
+    → Phase 2: Load and send in-range chunks not yet subscribed
+        → Iterates candidate coords (zigzag order, up to chunks_to_send limit)
+        → game_map().serialize_for_client(coord, load_if_missing=true, ...)
+            → ServerGameMap::get_chunk() — loads from DB or runs mapgen
+              → Deserialize blocks + extended data + lighting
+            → Protobuf encode as StoredChunk
+        → Snappy-compress encoded bytes
+        → Send StreamToClient { server_message: MapChunk { snappy_encoded_bytes } }
+          via outbound mpsc → NetPrioritizer → gRPC stream
+          (server-pushed; there is no client-initiated "request chunk" RPC)
+        → If chunks_to_send budget exhausted before all chunks sent: aimd.increase()
+          (signals server can send more next update)
+
+[Client InboundContext — client_workers.rs]
+  Receives StreamToClient::MapChunk
+  → handle_mapchunk()
+    → Snappy-decode → StoredChunk protobuf
+    → client_state.chunks.insert_or_update() — stores block IDs + client extended data
+    → Enqueue coord (+ neighbors) for neighbor propagation
+      → NeighborPropagator computes lighting neighbor data
+        → MeshWorker generates chunk mesh
+          → MeshBatcher batches draw calls
+            → Vulkan renders next frame
 ```
 
 ### Entity Coroutine


### PR DESCRIPTION
## Summary
Significantly expanded the navigation guide documentation in `.claude/SOURCEMAP_INDEX.md` to provide comprehensive, step-by-step walkthroughs of critical gameplay systems. The documentation now traces complete request/response flows from client input through server processing to final rendering.

## Key Changes

- **Player Interaction Flow (dig/place/tap)**: Added detailed breakdown showing:
  - Client-side input handling in `client_workers.rs` (OutboundContext)
  - Server-side permission checks and handler dispatch in `client_context.rs` (InboundWorker)
  - Atomic inventory mutations with proper locking semantics
  - Two-phase block interaction handlers (inline vs. full) with deadlock avoidance
  - Broadcast mechanism via `BlockEventSender` with chunk subscription filtering
  - Client-side mesh regeneration pipeline
  - Acknowledgment and pacing feedback loop

- **Chunk Loading Flow**: Added comprehensive walkthrough covering:
  - Client position update mechanism with backpressure signaling (`ClientPacing`)
  - Server-side AIMD (Additive Increase, Multiplicative Decrease) congestion control
  - Dual `MapChunkSender` instances with sharded processing
  - Chunk serialization, compression (Snappy), and prioritized network transmission
  - Client-side chunk deserialization and mesh generation pipeline
  - Lighting neighbor propagation and batched rendering

## Notable Implementation Details

- Documented the pacing feedback loop: client sends `pending_chunks` and `distance_limit` to inform server's AIMD controller
- Clarified the two-phase block handler pattern: inline handlers hold chunk locks for fast mutations; full handlers release locks first to prevent deadlocks
- Explained chunk subscription filtering and out-of-range unsubscription
- Detailed the zigzag chunk iteration order and budget-based sending strategy
- Documented the NeighborPropagator → MeshWorker → MeshBatcher → Vulkan rendering pipeline

This documentation serves as a reference guide for understanding the critical paths through the Perovskite engine's networking and gameplay systems.

https://claude.ai/code/session_012SCb8Ks2LBTE2mssoucZZt