### PR TITLE
Refactor refinement UI context to bundle atlas and client state

### DIFF
--- a/perovskite_client/src/game_ui/egui_ui.rs
+++ b/perovskite_client/src/game_ui/egui_ui.rs
@@ -11,6 +11,8 @@ use perovskite_core::protocol::items::{ItemDef, ItemStack};
 use perovskite_core::protocol::ui::{self as proto, PopupResponse};
 use perovskite_core::protocol::{items::item_def::QuantityType, ui::PopupDescription};
 
+use super::TextureAtlas;
+
 use super::hud::render_number;
 use super::{get_texture, FRAME_UNSELECTED};
 use crate::client_state::items::InventoryViewManager;
@@ -46,6 +48,14 @@ struct TextViewState {
     refinement: Option<Box<dyn RefinementState>>,
 }
 
+/// Context passed to refinement drawing functions, bundling the item atlas, client state,
+/// and the egui texture ID for the item atlas.
+pub(crate) struct RefinementsCtx<'a> {
+    pub(crate) atlas: &'a TextureAtlas,
+    pub(crate) client_state: &'a ClientState,
+    pub(crate) atlas_texture_id: TextureId,
+}
+
 pub(crate) trait RefinementState: Send + Sync {
     /// Draws the refinement UI.
     ///
@@ -55,13 +65,13 @@ pub(crate) trait RefinementState: Send + Sync {
     /// Arguments:
     /// * `provoking_response`: The response of the widget that opened this refinement,
     ///         currently the button at the end of the textbox that displays `[Self::open_button_text]`.
-    /// * `ctx`: The `Context` to use for drawing.
-    /// * `client_state`: The `ClientState` to use for drawing.
+    /// * `ctx`: The egui `Context` to use for drawing.
+    /// * `refinements_ctx`: Atlas, client state, and texture ID bundled together.
     fn draw(
         &mut self,
         provoking_response: &egui::Response,
         ctx: &Context,
-        client_state: &ClientState,
+        refinements_ctx: &RefinementsCtx<'_>,
         base_id: egui::Id,
     ) -> ControlFlow<Option<String>>;
 
@@ -72,8 +82,7 @@ pub(crate) trait RefinementState: Send + Sync {
 mod refinements;
 
 pub(crate) struct EguiUi {
-    texture_atlas: Arc<Texture2DHolder>,
-    atlas_coords: HashMap<String, texture_packer::Rect>,
+    item_atlas: Arc<TextureAtlas>,
     item_defs: Arc<ClientItemManager>,
 
     inventory_open: bool,
@@ -112,14 +121,12 @@ pub(crate) struct EguiUi {
 }
 impl EguiUi {
     pub(crate) fn new(
-        texture_atlas: Arc<Texture2DHolder>,
-        atlas_coords: HashMap<String, texture_packer::Rect>,
+        item_atlas: Arc<TextureAtlas>,
         item_defs: Arc<ClientItemManager>,
         settings: Arc<ArcSwap<GameSettings>>,
     ) -> EguiUi {
         EguiUi {
-            texture_atlas,
-            atlas_coords,
+            item_atlas,
             item_defs,
             inventory_open: false,
             pause_menu_open: false,
@@ -334,7 +341,7 @@ impl EguiUi {
                 ui.label(label);
             }
             Some(proto::ui_element::Element::TextField(text_field)) => {
-                self.render_text_field(ui, popup, id, client_state, text_field);
+                self.render_text_field(ui, popup, id, client_state, atlas_texture_id, text_field);
             }
             Some(proto::ui_element::Element::Checkbox(checkbox)) => {
                 let value = self
@@ -407,6 +414,7 @@ impl EguiUi {
         popup: &PopupDescription,
         id: Id,
         client_state: &ClientState,
+        atlas_texture_id: TextureId,
         text_field: &proto::TextField,
     ) {
         let value = self
@@ -427,6 +435,11 @@ impl EguiUi {
                     None => None,
                 },
             });
+        let refinements_ctx = RefinementsCtx {
+            atlas: &self.item_atlas,
+            client_state,
+            atlas_texture_id,
+        };
         ui.with_layout(egui::Layout::left_to_right(egui::Align::Min), |ui| {
             if text_field.multiline {
                 ScrollArea::both()
@@ -441,7 +454,7 @@ impl EguiUi {
                         if value.refinement_open {
                             let refinement = value.refinement.as_mut().unwrap();
                             if let ControlFlow::Break(new_value) =
-                                refinement.draw(&resp, ui.ctx(), client_state, id)
+                                refinement.draw(&resp, ui.ctx(), &refinements_ctx, id)
                             {
                                 value.refinement_open = false;
                                 if let Some(new_value) = new_value {
@@ -462,7 +475,7 @@ impl EguiUi {
                     if value.refinement_open {
                         let refinement = value.refinement.as_mut().unwrap();
                         if let ControlFlow::Break(new_value) =
-                            refinement.draw(&resp, ui.ctx(), client_state, id)
+                            refinement.draw(&resp, ui.ctx(), &refinements_ctx, id)
                         {
                             value.refinement_open = false;
                             if let Some(new_value) = new_value {
@@ -588,9 +601,9 @@ impl EguiUi {
 
             let x = self.stack_carried_by_mouse_offset.0 + self.last_mouse_position.x;
             let y = self.stack_carried_by_mouse_offset.1 + self.last_mouse_position.y;
-            let texture_rect = get_texture(&stack, &self.atlas_coords, &self.item_defs);
+            let texture_rect = get_texture(&stack, &self.item_atlas.coords, &self.item_defs);
             // only needed for its size, a bit inefficient but fine for now
-            let frame_pixels = *self.atlas_coords.get(FRAME_UNSELECTED).unwrap();
+            let frame_pixels = *self.item_atlas.coords.get(FRAME_UNSELECTED).unwrap();
             // todo get rid of this hardcoding :(
             let position_rect = texture_packer::Rect::new(
                 // These want the actual physical scale
@@ -602,7 +615,11 @@ impl EguiUi {
             );
 
             let mut builder = FlatTextureDrawBuilder::new();
-            builder.rect(position_rect, texture_rect, self.texture_atlas.dimensions());
+            builder.rect(
+                position_rect,
+                texture_rect,
+                self.item_atlas.texture.dimensions(),
+            );
             let frame_topright = (position_rect.right(), position_rect.top());
             // todo unify this with hud.rs
             if stack.stackable() && stack.quantity != 1 {
@@ -610,8 +627,8 @@ impl EguiUi {
                     frame_topright,
                     stack.quantity,
                     &mut builder,
-                    &self.atlas_coords,
-                    &self.texture_atlas,
+                    &self.item_atlas.coords,
+                    &self.item_atlas.texture,
                 )
             }
 
@@ -654,9 +671,9 @@ impl EguiUi {
             return;
         }
 
-        let frame_pixels = *self.atlas_coords.get(FRAME_UNSELECTED).unwrap();
+        let frame_pixels = *self.item_atlas.coords.get(FRAME_UNSELECTED).unwrap();
 
-        let frame_uv = self.pixel_rect_to_uv(frame_pixels);
+        let frame_uv = self.item_atlas.egui_uv(frame_pixels);
 
         let frame_size = if client_state
             .settings
@@ -760,9 +777,10 @@ impl EguiUi {
                             );
                             let wear_bucket = ((wear_level * 8.0) as u8).clamp(0, 7);
                             let wear_texture = format!("builtin:wear_{}", wear_bucket);
-                            let texture_uv = self.pixel_rect_to_uv(
+                            let texture_uv = self.item_atlas.egui_uv(
                                 *self
-                                    .atlas_coords
+                                    .item_atlas
+                                    .coords
                                     .get(&wear_texture)
                                     .unwrap_or_else(|| panic!("Missing texture {}", wear_texture)),
                             );
@@ -794,24 +812,12 @@ impl EguiUi {
     }
 
     pub(crate) fn clone_texture_atlas(&self) -> Arc<Texture2DHolder> {
-        self.texture_atlas.clone()
-    }
-
-    pub(crate) fn pixel_rect_to_uv(&self, pixel_rect: texture_packer::Rect) -> egui::Rect {
-        let width = self.texture_atlas.dimensions().0 as f32;
-        let height = self.texture_atlas.dimensions().1 as f32;
-        let left = pixel_rect.left() as f32 / width;
-        let right = (pixel_rect.right() + 1) as f32 / width;
-
-        let top = pixel_rect.top() as f32 / height;
-        let bottom = (pixel_rect.bottom() + 1) as f32 / height;
-
-        egui::Rect::from_x_y_ranges(left..=right, top..=bottom)
+        self.item_atlas.texture.clone()
     }
 
     pub(crate) fn get_texture_uv(&self, item: &ItemStack) -> egui::Rect {
-        let pixel_rect = get_texture(item, &self.atlas_coords, &self.item_defs);
-        self.pixel_rect_to_uv(pixel_rect)
+        let pixel_rect = get_texture(item, &self.item_atlas.coords, &self.item_defs);
+        self.item_atlas.egui_uv(pixel_rect)
     }
 
     fn draw_pause_menu(&mut self, ctx: &Context, client_state: &ClientState, enabled: bool) {

--- a/perovskite_client/src/game_ui/egui_ui/refinements.rs
+++ b/perovskite_client/src/game_ui/egui_ui/refinements.rs
@@ -1,11 +1,14 @@
-use crate::client_state::ClientState;
-use crate::game_ui::egui_ui::RefinementState;
+use crate::game_ui::UNKNOWN_TEXTURE;
+use crate::game_ui::egui_ui::RefinementsCtx;
+use egui::load::SizedTexture;
 use egui::Context;
 use itertools::Itertools;
 use perovskite_core::block_id::BlockId;
 use perovskite_core::protocol::blocks::BlockTypeDef;
 use perovskite_core::protocol::items::ItemDef;
 use std::ops::ControlFlow;
+
+use super::RefinementState;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 enum CategorySelection {
@@ -41,10 +44,10 @@ impl<T: RefinementItem> RefinementState for CategoryPickerRefinement<T> {
         &mut self,
         _provoking_response: &egui::Response,
         ctx: &Context,
-        client_state: &ClientState,
+        refinements_ctx: &RefinementsCtx<'_>,
         base_id: egui::Id,
     ) -> ControlFlow<Option<String>> {
-        draw_refinement_picker::<T>(&mut self.state, ctx, client_state, base_id)
+        draw_refinement_picker::<T>(&mut self.state, ctx, refinements_ctx, base_id)
     }
 
     fn open_button_text(&self) -> &str {
@@ -63,14 +66,15 @@ pub(crate) trait RefinementItem: Sized {
     fn short_name(&self) -> &str;
     fn groups(&self) -> &[String];
     fn descriptive_name(&self) -> &str;
-    fn render_details(&self, ui: &mut egui::Ui, client_state: &ClientState);
+    fn render_details(&self, ui: &mut egui::Ui, ctx: &RefinementsCtx<'_>);
 
-    fn get_all_items<'a>(client_state: &'a ClientState) -> impl Iterator<Item = &'a Self>
+    /// Returns all items; `'a` is the lifetime of the data held inside `RefinementsCtx`.
+    fn get_all_items<'a>(refinements_ctx: &RefinementsCtx<'a>) -> impl Iterator<Item = &'a Self>
     where
         Self: 'a;
-    fn get_all_groups(client_state: &ClientState) -> &[String];
-    fn get_all_plugin_prefixes(client_state: &ClientState) -> &[String];
-    fn get_by_name<'a>(client_state: &'a ClientState, name: &str) -> Option<&'a Self>;
+    fn get_all_groups<'a>(refinements_ctx: &RefinementsCtx<'a>) -> &'a [String];
+    fn get_all_plugin_prefixes<'a>(refinements_ctx: &RefinementsCtx<'a>) -> &'a [String];
+    fn get_by_name<'a>(refinements_ctx: &RefinementsCtx<'a>, name: &str) -> Option<&'a Self>;
 }
 impl RefinementItem for ItemDef {
     fn short_name(&self) -> &str {
@@ -82,24 +86,40 @@ impl RefinementItem for ItemDef {
     fn descriptive_name(&self) -> &str {
         &self.display_name
     }
-    fn render_details(&self, ui: &mut egui::Ui, _client_state: &ClientState) {
-        ui.label("TODO: More info and a picture...");
+    fn render_details(&self, ui: &mut egui::Ui, ctx: &RefinementsCtx<'_>) {
+        let fallback = ctx.atlas.coords.get(UNKNOWN_TEXTURE).copied();
+        if let Some(pixel_rect) = ctx
+            .atlas
+            .coords
+            .get(&self.short_name)
+            .copied()
+            .or(fallback)
+        {
+            let uv = ctx.atlas.egui_uv(pixel_rect);
+            let image = egui::Image::from_texture(SizedTexture {
+                id: ctx.atlas_texture_id,
+                size: egui::vec2(64.0, 64.0),
+            })
+            .uv(uv);
+            ui.add(image);
+        }
+        ui.label(&self.display_name);
     }
 
-    fn get_all_items<'a>(client_state: &'a ClientState) -> impl Iterator<Item = &'a Self>
+    fn get_all_items<'a>(refinements_ctx: &RefinementsCtx<'a>) -> impl Iterator<Item = &'a Self>
     where
         Self: 'a,
     {
-        client_state.items.sorted_items()
+        refinements_ctx.client_state.items.sorted_items()
     }
-    fn get_all_groups(client_state: &ClientState) -> &[String] {
-        client_state.items.groups()
+    fn get_all_groups<'a>(refinements_ctx: &RefinementsCtx<'a>) -> &'a [String] {
+        refinements_ctx.client_state.items.groups()
     }
-    fn get_all_plugin_prefixes(client_state: &ClientState) -> &[String] {
-        client_state.items.plugin_prefixes()
+    fn get_all_plugin_prefixes<'a>(refinements_ctx: &RefinementsCtx<'a>) -> &'a [String] {
+        refinements_ctx.client_state.items.plugin_prefixes()
     }
-    fn get_by_name<'a>(client_state: &'a ClientState, name: &str) -> Option<&'a Self> {
-        client_state.items.get(name)
+    fn get_by_name<'a>(refinements_ctx: &RefinementsCtx<'a>, name: &str) -> Option<&'a Self> {
+        refinements_ctx.client_state.items.get(name)
     }
 }
 impl RefinementItem for BlockTypeDef {
@@ -113,23 +133,32 @@ impl RefinementItem for BlockTypeDef {
         &self.short_name
     }
 
-    fn get_all_items<'a>(client_state: &'a ClientState) -> impl Iterator<Item = &'a Self>
+    fn get_all_items<'a>(refinements_ctx: &RefinementsCtx<'a>) -> impl Iterator<Item = &'a Self>
     where
         Self: 'a,
     {
-        client_state.block_types.sorted_blocks_by_name()
+        refinements_ctx
+            .client_state
+            .block_types
+            .sorted_blocks_by_name()
     }
-    fn get_all_groups(client_state: &ClientState) -> &[String] {
-        client_state.block_types.groups()
+    fn get_all_groups<'a>(refinements_ctx: &RefinementsCtx<'a>) -> &'a [String] {
+        refinements_ctx.client_state.block_types.groups()
     }
-    fn get_all_plugin_prefixes(client_state: &ClientState) -> &[String] {
-        client_state.block_types.plugin_prefixes()
+    fn get_all_plugin_prefixes<'a>(refinements_ctx: &RefinementsCtx<'a>) -> &'a [String] {
+        refinements_ctx.client_state.block_types.plugin_prefixes()
     }
-    fn get_by_name<'a>(client_state: &'a ClientState, name: &str) -> Option<&'a Self> {
-        let block_id = client_state.block_types.get_block_by_name(name)?;
-        client_state.block_types.get_blockdef(block_id)
+    fn get_by_name<'a>(refinements_ctx: &RefinementsCtx<'a>, name: &str) -> Option<&'a Self> {
+        let block_id = refinements_ctx
+            .client_state
+            .block_types
+            .get_block_by_name(name)?;
+        refinements_ctx
+            .client_state
+            .block_types
+            .get_blockdef(block_id)
     }
-    fn render_details(&self, ui: &mut egui::Ui, _client_state: &ClientState) {
+    fn render_details(&self, ui: &mut egui::Ui, _ctx: &RefinementsCtx<'_>) {
         ui.label(format!("Block ID: {:?}", BlockId(self.id)));
         ui.label(format!(
             "Groups: {}",
@@ -141,7 +170,7 @@ impl RefinementItem for BlockTypeDef {
 fn draw_refinement_picker<T: RefinementItem>(
     state: &mut PickerState,
     ctx: &Context,
-    client_state: &ClientState,
+    refinements_ctx: &RefinementsCtx<'_>,
     base_id: egui::Id,
 ) -> ControlFlow<Option<String>> {
     let response = egui::Modal::new(base_id.with("refinement_picker")).show(ctx, |ui| {
@@ -199,7 +228,7 @@ fn draw_refinement_picker<T: RefinementItem>(
                                 }
                                 ui.end_row();
 
-                                for group in T::get_all_groups(client_state) {
+                                for group in T::get_all_groups(refinements_ctx) {
                                     if ui
                                         .selectable_value(
                                             &mut state.selected_category,
@@ -214,7 +243,7 @@ fn draw_refinement_picker<T: RefinementItem>(
                                     }
                                     ui.end_row();
                                 }
-                                for prefix in T::get_all_plugin_prefixes(client_state) {
+                                for prefix in T::get_all_plugin_prefixes(refinements_ctx) {
                                     if ui
                                         .selectable_value(
                                             &mut state.selected_category,
@@ -238,8 +267,8 @@ fn draw_refinement_picker<T: RefinementItem>(
             .min_width(160.0)
             .show_inside(ui, |ui| {
                 if let Some(item_name) = &state.selected_item {
-                    if let Some(item) = T::get_by_name(client_state, item_name) {
-                        item.render_details(ui, client_state);
+                    if let Some(item) = T::get_by_name(refinements_ctx, item_name) {
+                        item.render_details(ui, refinements_ctx);
                     } else {
                         ui.label("Unknown selection");
                     }
@@ -261,9 +290,12 @@ fn draw_refinement_picker<T: RefinementItem>(
                             .striped(true)
                             .show(ui, |ui| {
                                 let filter = state.selected_category.make_filter::<T>();
-                                for item in T::get_all_items(client_state).filter(|item| {
-                                    filter(item) && item.short_name().contains(&state.typing_filter)
-                                }) {
+                                for item in
+                                    T::get_all_items(refinements_ctx).filter(|item| {
+                                        filter(item)
+                                            && item.short_name().contains(&state.typing_filter)
+                                    })
+                                {
                                     let response = ui
                                         .selectable_value(
                                             &mut state.selected_item,

--- a/perovskite_client/src/game_ui/mod.rs
+++ b/perovskite_client/src/game_ui/mod.rs
@@ -22,6 +22,25 @@ use anyhow::{bail, Error, Result};
 use arc_swap::ArcSwap;
 use perovskite_core::protocol::items::item_def::Appearance;
 
+/// Item UI texture atlas: holds the egui-side texture and per-item pixel rects.
+pub(crate) struct TextureAtlas {
+    pub(crate) texture: Arc<Texture2DHolder>,
+    pub(crate) coords: HashMap<String, texture_packer::Rect>,
+}
+
+impl TextureAtlas {
+    /// Convert a pixel rect (in atlas space) to egui UV coordinates [0, 1].
+    pub(crate) fn egui_uv(&self, pixel_rect: texture_packer::Rect) -> egui::Rect {
+        let width = self.texture.dimensions().0 as f32;
+        let height = self.texture.dimensions().1 as f32;
+        let left = pixel_rect.left() as f32 / width;
+        let right = (pixel_rect.right() + 1) as f32 / width;
+        let top = pixel_rect.top() as f32 / height;
+        let bottom = (pixel_rect.bottom() + 1) as f32 / height;
+        egui::Rect::from_x_y_ranges(left..=right, top..=bottom)
+    }
+}
+
 pub(crate) mod egui_ui;
 pub(crate) mod hud;
 
@@ -35,9 +54,14 @@ pub(crate) async fn make_uis(
     let (texture_atlas, texture_coords) =
         build_texture_atlas(&item_defs, cache_manager, ctx, block_renderer).await?;
 
+    let item_atlas = Arc::new(TextureAtlas {
+        texture: texture_atlas.clone(),
+        coords: texture_coords.clone(),
+    });
+
     let hud = GameHud {
-        texture_coords: texture_coords.clone(),
-        texture_atlas: texture_atlas.clone(),
+        texture_coords,
+        texture_atlas,
         item_defs: item_defs.clone(),
         last_size: (0, 0),
         hotbar_slot: 0,
@@ -47,7 +71,7 @@ pub(crate) async fn make_uis(
         fps_counter: fps_counter::FPSCounter::new(),
     };
 
-    let egui_ui = EguiUi::new(texture_atlas, texture_coords, item_defs.clone(), settings);
+    let egui_ui = EguiUi::new(item_atlas, item_defs.clone(), settings);
 
     Ok((hud, egui_ui))
 }
@@ -285,4 +309,4 @@ const DIGIT_ATLAS: &str = "builtin:digit_atlas";
 const FRAME_SELECTED: &str = "builtin:frame_selected";
 const FRAME_UNSELECTED: &str = "builtin:frame_unselected";
 const TEST_ITEM: &str = "builtin:test_item";
-const UNKNOWN_TEXTURE: &str = "builtin:unknown";
+pub(crate) const UNKNOWN_TEXTURE: &str = "builtin:unknown";


### PR DESCRIPTION
## Summary
This PR refactors the refinement UI system to use a bundled context struct (`RefinementsCtx`) instead of passing `ClientState` directly. It also introduces a new `TextureAtlas` struct to encapsulate texture data and coordinates, improving code organization and enabling item preview rendering in refinement details.

## Key Changes

- **New `TextureAtlas` struct**: Consolidates texture holder and coordinate mappings into a single struct with an `egui_uv()` helper method for converting pixel rects to UV coordinates
- **New `RefinementsCtx` struct**: Bundles `TextureAtlas`, `ClientState`, and the egui texture ID for refinement drawing functions, replacing direct `ClientState` parameter passing
- **Updated `RefinementState` trait**: Changed `draw()` method signature to accept `RefinementsCtx` instead of `ClientState`
- **Updated `RefinementItem` trait**: All methods now accept `RefinementsCtx` instead of `ClientState`, with explicit lifetime annotations for borrowed data
- **Item preview rendering**: Implemented actual item texture rendering in `ItemDef::render_details()` using the atlas, replacing the placeholder "TODO" text
- **Simplified `EguiUi` struct**: Replaced separate `texture_atlas` and `atlas_coords` fields with a single `item_atlas` field
- **Removed `pixel_rect_to_uv()` method**: Moved this functionality to `TextureAtlas::egui_uv()`
- **Made `UNKNOWN_TEXTURE` public**: Changed from private to `pub(crate)` for use in refinement rendering

## Implementation Details

The refactoring improves separation of concerns by grouping related texture data together and providing a cleaner API for refinement UI functions. The `RefinementsCtx` struct makes it explicit what data is available to refinement drawing code, and the lifetime parameter ensures proper borrowing semantics for data held within the context.

https://claude.ai/code/session_01GMRdraGgtudcrJPxrqDirf