### PR TITLE
Add place anchor formatting to player action logger

### DIFF
--- a/perovskite_game_api/src/bin/dev_server.rs
+++ b/perovskite_game_api/src/bin/dev_server.rs
@@ -13,7 +13,8 @@ use chrono::Local;
 use parking_lot::Mutex;
 use perovskite_core::protocol::game_rpc::{
     self as proto, dig_tap_action::ActionTarget as DigTapTarget,
-    interact_key_action::InteractionTarget, stream_to_server::ClientMessage,
+    interact_key_action::InteractionTarget, place_action::PlaceAnchor,
+    stream_to_server::ClientMessage,
 };
 use perovskite_game_api::{
     default_game::basic_blocks::DIRT, game_builder::GameBuilder, test_support::GameBuilderTestExt,
@@ -65,6 +66,14 @@ fn format_dig_target(target: &Option<DigTapTarget>) -> String {
     }
 }
 
+fn format_place_anchor(anchor: &Option<PlaceAnchor>) -> String {
+    match anchor {
+        None => "none".to_string(),
+        Some(PlaceAnchor::AnchorBlock(c)) => format!("block({},{},{})", c.x, c.y, c.z),
+        Some(PlaceAnchor::AnchorEntity(e)) => format!("entity({})", e.entity_id),
+    }
+}
+
 fn format_interact_target(target: &Option<InteractionTarget>) -> String {
     match target {
         None => "none".to_string(),
@@ -111,9 +120,11 @@ impl GameStreamInterceptors for PlayerActionLogger {
             ),
             Some(ClientMessage::Place(m)) => {
                 let coord = m.block_coord.as_ref();
-                let target = coord
+                let block_coord = coord
                     .map(|c| format!("block({},{},{})", c.x, c.y, c.z))
                     .unwrap_or_else(|| "none".to_string());
+                let anchor = format_place_anchor(&m.place_anchor);
+                let target = format!("{} anchor={}", block_coord, anchor);
                 ("place", m.item_slot, target, format_player_pos(&m.position))
             }
             Some(ClientMessage::InteractKey(m)) => (


### PR DESCRIPTION
## Summary
Enhanced the player action logger in the dev server to display placement anchor information alongside block coordinates when logging place actions.

## Key Changes
- Added `PlaceAnchor` import from the protocol to support anchor type handling
- Introduced `format_place_anchor()` helper function to format anchor data, supporting both block-based anchors (with x, y, z coordinates) and entity-based anchors (with entity ID)
- Updated place action logging to include anchor information in the target output, displaying both the block coordinate and anchor in a unified format

## Implementation Details
The `format_place_anchor()` function handles the `PlaceAnchor` enum variants:
- `None`: displays as "none"
- `AnchorBlock`: displays as "block(x,y,z)"
- `AnchorEntity`: displays as "entity(id)"

The place action log message now shows both the block coordinate and anchor information, providing more complete context for debugging placement actions.

https://claude.ai/code/session_015juDsDE58mPY2ES5LsdFvq