### PR TITLE
Add game stream interceptors for action logging and record/replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dhat-heap.json
 *.png~
 *.spv
 *.local.json
+recording_*.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,8 +830,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -3926,6 +3928,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "cgmath",
+ "chrono",
  "circular-buffer",
  "console-subscriber",
  "criterion 0.4.0",

--- a/perovskite_game_api/Cargo.toml
+++ b/perovskite_game_api/Cargo.toml
@@ -60,6 +60,7 @@ smartstring = "1.0.1"
 tokio-util = "0.7.14"
 googletest = { version = "0.14.2", optional = true }
 arc-swap = "1.8.0"
+chrono = "0.4"
 ndarray = "0.17.2"
 strum = "0.28.0"
 strum_macros = "0.28.0"
@@ -149,6 +150,11 @@ harness = false
 name = "perovskite_game_api"
 path = "src/main.rs"
 required-features = ["default_game", "server"]
+
+[[bin]]
+name = "dev_server"
+path = "src/bin/dev_server.rs"
+required-features = ["default_game", "server", "test-support"]
 
 [[bin]]
 name = "summarize_textures"

--- a/perovskite_game_api/benches/game_map_bench.rs
+++ b/perovskite_game_api/benches/game_map_bench.rs
@@ -17,7 +17,7 @@ impl AsyncExecutor for AsyncExecutorAdapter {
 }
 
 fn map_benchmarks(c: &mut Criterion) {
-    let (mut game, work_dir) = GameBuilder::testonly_in_memory().unwrap();
+    let (mut game, work_dir) = GameBuilder::testonly_in_memory(None).unwrap();
     game.initialize_default_game().unwrap();
     carts::register_carts(&mut game).unwrap();
     game.run_task_in_server(|gs| {

--- a/perovskite_game_api/benches/mapgen_bench.rs
+++ b/perovskite_game_api/benches/mapgen_bench.rs
@@ -4,7 +4,7 @@ use perovskite_game_api::{
 };
 
 fn chunk_benchmarks(c: &mut Criterion) {
-    let (mut game, work_dir) = GameBuilder::testonly_in_memory().unwrap();
+    let (mut game, work_dir) = GameBuilder::testonly_in_memory(None).unwrap();
     game.initialize_default_game().unwrap();
     carts::register_carts(&mut game).unwrap();
     game.force_seed(Some(0));

--- a/perovskite_game_api/src/bin/dev_server.rs
+++ b/perovskite_game_api/src/bin/dev_server.rs
@@ -1,0 +1,189 @@
+// Dev server entry point for rapid iteration and record/replay based testing.
+//
+// Brings up the default game with a flat dirt map and logs player actions to a
+// timestamped recording file in the current working directory.
+
+use std::{
+    io::{BufWriter, Write},
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use chrono::Local;
+use parking_lot::Mutex;
+use perovskite_core::protocol::game_rpc::{
+    self as proto,
+    dig_tap_action::ActionTarget as DigTapTarget,
+    interact_key_action::InteractionTarget,
+    stream_to_server::ClientMessage,
+};
+use perovskite_game_api::{
+    default_game::basic_blocks::DIRT,
+    game_builder::GameBuilder,
+    test_support::GameBuilderTestExt,
+};
+use perovskite_server::game_state::{player::Player, GameState, GameStreamInterceptors};
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::prelude::*;
+
+/// Rounded step for spatial position logging (in blocks).
+const POSITION_ROUND_UNIT: f64 = 0.25;
+/// Rounded step for angular logging (in degrees).
+const ANGLE_ROUND_DEGREES: f64 = 15.0;
+
+fn round_to(value: f64, unit: f64) -> f64 {
+    (value / unit).round() * unit
+}
+
+fn format_player_pos(pos: &Option<proto::PlayerPosition>) -> String {
+    match pos {
+        None => "none".to_string(),
+        Some(p) => {
+            let xyz = p.position.as_ref();
+            let dir = p.face_direction.as_ref();
+            let x = xyz.map(|v| round_to(v.x, POSITION_ROUND_UNIT)).unwrap_or(0.0);
+            let y = xyz.map(|v| round_to(v.y, POSITION_ROUND_UNIT)).unwrap_or(0.0);
+            let z = xyz.map(|v| round_to(v.z, POSITION_ROUND_UNIT)).unwrap_or(0.0);
+            let az = dir
+                .map(|a| round_to(a.deg_azimuth, ANGLE_ROUND_DEGREES))
+                .unwrap_or(0.0);
+            let el = dir
+                .map(|a| round_to(a.deg_elevation, ANGLE_ROUND_DEGREES))
+                .unwrap_or(0.0);
+            format!("({x:.2},{y:.2},{z:.2}) az={az:.0} el={el:.0}")
+        }
+    }
+}
+
+fn format_dig_target(target: &Option<DigTapTarget>) -> String {
+    match target {
+        None => "none".to_string(),
+        Some(DigTapTarget::BlockCoord(c)) => format!("block({},{},{})", c.x, c.y, c.z),
+        Some(DigTapTarget::EntityTarget(e)) => format!("entity({})", e.entity_id),
+    }
+}
+
+fn format_interact_target(target: &Option<InteractionTarget>) -> String {
+    match target {
+        None => "none".to_string(),
+        Some(InteractionTarget::BlockCoord(c)) => format!("block({},{},{})", c.x, c.y, c.z),
+        Some(InteractionTarget::EntityTarget(e)) => format!("entity({})", e.entity_id),
+    }
+}
+
+struct PlayerActionLogger {
+    writer: Mutex<BufWriter<std::fs::File>>,
+}
+
+impl PlayerActionLogger {
+    fn new() -> Result<Self> {
+        let filename = format!(
+            "recording_{}.txt",
+            Local::now().format("%Y%m%d_%H%M%S")
+        );
+        let file =
+            std::fs::File::create(&filename).with_context(|| format!("create {filename}"))?;
+        tracing::info!("Recording player actions to {filename}");
+        Ok(Self {
+            writer: Mutex::new(BufWriter::new(file)),
+        })
+    }
+}
+
+impl GameStreamInterceptors for PlayerActionLogger {
+    fn handle_message(
+        &self,
+        message: &proto::StreamToServer,
+        game_state: &GameState,
+        player: &Player,
+    ) -> Result<()> {
+        let (action, item_slot, target, pos) = match &message.client_message {
+            Some(ClientMessage::Dig(m)) => (
+                "dig",
+                m.item_slot,
+                format_dig_target(&m.action_target),
+                format_player_pos(&m.position),
+            ),
+            Some(ClientMessage::Tap(m)) => (
+                "tap",
+                m.item_slot,
+                format_dig_target(&m.action_target),
+                format_player_pos(&m.position),
+            ),
+            Some(ClientMessage::Place(m)) => {
+                let coord = m.block_coord.as_ref();
+                let target = coord
+                    .map(|c| format!("block({},{},{})", c.x, c.y, c.z))
+                    .unwrap_or_else(|| "none".to_string());
+                (
+                    "place",
+                    m.item_slot,
+                    target,
+                    format_player_pos(&m.position),
+                )
+            }
+            Some(ClientMessage::InteractKey(m)) => (
+                "interact",
+                m.item_slot,
+                format_interact_target(&m.interaction_target),
+                format_player_pos(&m.position),
+            ),
+            _ => return Ok(()),
+        };
+
+        let inv = game_state
+            .inventory_manager()
+            .get(&player.main_inventory())?;
+        let item_desc = match inv {
+            None => "no_inventory".to_string(),
+            Some(inv) => match inv.contents().get(item_slot as usize) {
+                Some(Some(stack)) => {
+                    format!("{}:{}", stack.item_name(), stack.quantity_or_wear())
+                }
+                Some(None) => "empty".to_string(),
+                None => format!("slot_{item_slot}_oob"),
+            },
+        };
+
+        let line = format!(
+            "action={action} player={name} item_slot={item_slot} item={item_desc} target={target} player_pos={pos}\n",
+            name = player.name(),
+        );
+
+        self.writer.lock().write_all(line.as_bytes())?;
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            ),
+        )
+        .init();
+
+    let (mut game, temp_dir) = GameBuilder::testonly_in_memory()?;
+    perovskite_game_api::configure_default_game(&mut game)?;
+
+    // Override with a simple flat dirt world instead of the complex default mapgen.
+    let dirt = game
+        .get_block(DIRT)
+        .expect("dirt block not registered after configure_default_game");
+    game.set_flatland_mapgen(dirt);
+
+    let logger = Arc::new(PlayerActionLogger::new()?);
+    game.set_stream_interceptors(logger);
+
+    game.run_game_server()?;
+
+    tracing::info!("Dev server has shut down; cleaning up temp dir");
+    if let Err(e) = std::fs::remove_dir_all(&temp_dir) {
+        tracing::warn!("Failed to remove temp dir {:?}: {e}", temp_dir);
+    }
+
+    Ok(())
+}

--- a/perovskite_game_api/src/bin/dev_server.rs
+++ b/perovskite_game_api/src/bin/dev_server.rs
@@ -13,7 +13,8 @@ use chrono::Local;
 use parking_lot::Mutex;
 use perovskite_core::protocol::game_rpc::{
     self as proto, dig_tap_action::ActionTarget as DigTapTarget,
-    interact_key_action::InteractionTarget, stream_to_server::ClientMessage,
+    interact_key_action::InteractionTarget, place_action::PlaceAnchor,
+    stream_to_server::ClientMessage,
 };
 use perovskite_game_api::{
     default_game::basic_blocks::DIRT, game_builder::GameBuilder, test_support::GameBuilderTestExt,
@@ -65,6 +66,14 @@ fn format_dig_target(target: &Option<DigTapTarget>) -> String {
     }
 }
 
+fn format_place_anchor(anchor: &Option<PlaceAnchor>) -> String {
+    match anchor {
+        None => "none".to_string(),
+        Some(PlaceAnchor::AnchorBlock(c)) => format!("block({},{},{})", c.x, c.y, c.z),
+        Some(PlaceAnchor::AnchorEntity(e)) => format!("entity({})", e.entity_id),
+    }
+}
+
 fn format_interact_target(target: &Option<InteractionTarget>) -> String {
     match target {
         None => "none".to_string(),
@@ -111,9 +120,11 @@ impl GameStreamInterceptors for PlayerActionLogger {
             ),
             Some(ClientMessage::Place(m)) => {
                 let coord = m.block_coord.as_ref();
-                let target = coord
+                let block_coord = coord
                     .map(|c| format!("block({},{},{})", c.x, c.y, c.z))
                     .unwrap_or_else(|| "none".to_string());
+                let anchor = format_place_anchor(&m.place_anchor);
+                let target = format!("{} anchor={}", block_coord, anchor);
                 ("place", m.item_slot, target, format_player_pos(&m.position))
             }
             Some(ClientMessage::InteractKey(m)) => (

--- a/perovskite_game_api/src/bin/dev_server.rs
+++ b/perovskite_game_api/src/bin/dev_server.rs
@@ -12,15 +12,11 @@ use anyhow::{Context, Result};
 use chrono::Local;
 use parking_lot::Mutex;
 use perovskite_core::protocol::game_rpc::{
-    self as proto,
-    dig_tap_action::ActionTarget as DigTapTarget,
-    interact_key_action::InteractionTarget,
-    stream_to_server::ClientMessage,
+    self as proto, dig_tap_action::ActionTarget as DigTapTarget,
+    interact_key_action::InteractionTarget, stream_to_server::ClientMessage,
 };
 use perovskite_game_api::{
-    default_game::basic_blocks::DIRT,
-    game_builder::GameBuilder,
-    test_support::GameBuilderTestExt,
+    default_game::basic_blocks::DIRT, game_builder::GameBuilder, test_support::GameBuilderTestExt,
 };
 use perovskite_server::game_state::{player::Player, GameState, GameStreamInterceptors};
 use tracing::metadata::LevelFilter;
@@ -41,9 +37,15 @@ fn format_player_pos(pos: &Option<proto::PlayerPosition>) -> String {
         Some(p) => {
             let xyz = p.position.as_ref();
             let dir = p.face_direction.as_ref();
-            let x = xyz.map(|v| round_to(v.x, POSITION_ROUND_UNIT)).unwrap_or(0.0);
-            let y = xyz.map(|v| round_to(v.y, POSITION_ROUND_UNIT)).unwrap_or(0.0);
-            let z = xyz.map(|v| round_to(v.z, POSITION_ROUND_UNIT)).unwrap_or(0.0);
+            let x = xyz
+                .map(|v| round_to(v.x, POSITION_ROUND_UNIT))
+                .unwrap_or(0.0);
+            let y = xyz
+                .map(|v| round_to(v.y, POSITION_ROUND_UNIT))
+                .unwrap_or(0.0);
+            let z = xyz
+                .map(|v| round_to(v.z, POSITION_ROUND_UNIT))
+                .unwrap_or(0.0);
             let az = dir
                 .map(|a| round_to(a.deg_azimuth, ANGLE_ROUND_DEGREES))
                 .unwrap_or(0.0);
@@ -77,10 +79,7 @@ struct PlayerActionLogger {
 
 impl PlayerActionLogger {
     fn new() -> Result<Self> {
-        let filename = format!(
-            "recording_{}.txt",
-            Local::now().format("%Y%m%d_%H%M%S")
-        );
+        let filename = format!("recording_{}.txt", Local::now().format("%Y%m%d_%H%M%S"));
         let file =
             std::fs::File::create(&filename).with_context(|| format!("create {filename}"))?;
         tracing::info!("Recording player actions to {filename}");
@@ -115,12 +114,7 @@ impl GameStreamInterceptors for PlayerActionLogger {
                 let target = coord
                     .map(|c| format!("block({},{},{})", c.x, c.y, c.z))
                     .unwrap_or_else(|| "none".to_string());
-                (
-                    "place",
-                    m.item_slot,
-                    target,
-                    format_player_pos(&m.position),
-                )
+                ("place", m.item_slot, target, format_player_pos(&m.position))
             }
             Some(ClientMessage::InteractKey(m)) => (
                 "interact",
@@ -166,7 +160,7 @@ fn main() -> Result<()> {
         )
         .init();
 
-    let (mut game, temp_dir) = GameBuilder::testonly_in_memory()?;
+    let (mut game, temp_dir) = GameBuilder::testonly_in_memory(Some(28275))?;
     perovskite_game_api::configure_default_game(&mut game)?;
 
     // Override with a simple flat dirt world instead of the complex default mapgen.

--- a/perovskite_game_api/src/bin/dump_blocks.rs
+++ b/perovskite_game_api/src/bin/dump_blocks.rs
@@ -1,7 +1,7 @@
 use perovskite_game_api::game_builder::GameBuilder;
 
 fn main() {
-    let (mut game, _data_dir) = GameBuilder::testonly_in_memory().unwrap();
+    let (mut game, _data_dir) = GameBuilder::testonly_in_memory(None).unwrap();
     perovskite_game_api::configure_default_game(&mut game).unwrap();
     let mut blocks = game
         .run_task_in_server(|gs| {

--- a/perovskite_game_api/src/bin/summarize_textures.rs
+++ b/perovskite_game_api/src/bin/summarize_textures.rs
@@ -6,7 +6,7 @@ use perovskite_core::protocol::render::TextureReference;
 use perovskite_game_api::game_builder::GameBuilder;
 
 fn main() {
-    let (mut game, _data_dir) = GameBuilder::testonly_in_memory().unwrap();
+    let (mut game, _data_dir) = GameBuilder::testonly_in_memory(None).unwrap();
     perovskite_game_api::configure_default_game(&mut game).unwrap();
     let (mut blocks, mut items) = game
         .run_task_in_server(|gs| {

--- a/perovskite_game_api/src/game_builder.rs
+++ b/perovskite_game_api/src/game_builder.rs
@@ -368,8 +368,11 @@ impl GameBuilder {
         )
     }
 
-    pub fn testonly_in_memory() -> Result<(GameBuilder, PathBuf)> {
-        let (args, data_dir) = Self::tempdir_args();
+    pub fn testonly_in_memory(port: Option<u16>) -> Result<(GameBuilder, PathBuf)> {
+        let (mut args, data_dir) = Self::tempdir_args();
+        if let Some(p) = port {
+            args.port = p;
+        }
         let db = Arc::new(InMemGameDatabase::new());
         let builder = ServerBuilder::from_args_and_db(&args, db)?;
 

--- a/perovskite_game_api/src/game_builder.rs
+++ b/perovskite_game_api/src/game_builder.rs
@@ -38,7 +38,7 @@ use perovskite_server::{
         chat::commands::ChatCommandHandler,
         game_map::timers::{TimerCallback, TimerSettings},
         items::Item,
-        GameState,
+        GameState, GameStreamInterceptors,
     },
     server::{Server, ServerArgs, ServerBuilder},
 };
@@ -519,6 +519,12 @@ impl GameBuilder {
     /// Returns the handle for a previously-registered block, or `None` if not found.
     pub fn get_block(&self, block_name: StaticBlockName) -> Option<BlockId> {
         self.inner.blocks().get_by_name(block_name.0)
+    }
+
+    /// Sets stream interceptors that observe every inbound client message before it is
+    /// processed. Useful for action logging and record/replay tooling.
+    pub fn set_stream_interceptors(&mut self, interceptors: Arc<dyn GameStreamInterceptors>) {
+        self.inner.stream_interceptors = Some(interceptors);
     }
 
     /// Returns the [`SoundKey`] for a previously-registered sound, or `None` if not found.

--- a/perovskite_game_api/src/lib.rs
+++ b/perovskite_game_api/src/lib.rs
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn game_startup() {
-        let (mut game, _data_dir) = game_builder::GameBuilder::testonly_in_memory().unwrap();
+        let (mut game, _data_dir) = game_builder::GameBuilder::testonly_in_memory(None).unwrap();
         configure_default_game(&mut game).unwrap();
     }
 }

--- a/perovskite_server/src/game_state/mod.rs
+++ b/perovskite_server/src/game_state/mod.rs
@@ -49,6 +49,22 @@ use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use type_map::concurrent::TypeMap;
 
+/// Trait for intercepting inbound game stream messages before they are processed.
+///
+/// Implementations receive each client message as it arrives from the network, along
+/// with the current game state and the sending player. This hook runs synchronously
+/// before any inventory or map locks are taken, making it suitable for logging or
+/// lightweight inspection. Blocking inside `handle_message` is acceptable for
+/// developer/test tooling.
+pub trait GameStreamInterceptors: Send + Sync + 'static {
+    fn handle_message(
+        &self,
+        message: &perovskite_core::protocol::game_rpc::StreamToServer,
+        game_state: &GameState,
+        player: &player::Player,
+    ) -> Result<()>;
+}
+
 use self::blocks::BlockTypeManager;
 use self::chat::commands::CommandManager;
 use self::chat::ChatState;
@@ -108,6 +124,7 @@ pub struct GameState {
     startup_time: Instant,
     /// The number of times the server has been started.
     startup_counter: u64,
+    pub(crate) stream_interceptors: Option<Arc<dyn GameStreamInterceptors>>,
 }
 
 impl GameState {
@@ -126,6 +143,7 @@ impl GameState {
         extensions: type_map::concurrent::TypeMap,
         startup_counter: u64,
         force_seed: Option<u32>,
+        stream_interceptors: Option<Arc<dyn GameStreamInterceptors>>,
     ) -> Result<Arc<Self>> {
         let server_start_time = Instant::now();
         let mapgen_seed = get_or_create_seed(db.as_ref(), b"mapgen_seed", force_seed)?;
@@ -163,6 +181,7 @@ impl GameState {
             extensions,
             startup_time: Instant::now(),
             startup_counter,
+            stream_interceptors,
         });
         result.entities.clone().start_workers(result.clone());
         Ok(result)

--- a/perovskite_server/src/network_server/client_context.rs
+++ b/perovskite_server/src/network_server/client_context.rs
@@ -96,6 +96,7 @@ use tracy_client::plot;
 use tracy_client::span;
 
 use super::grpc_service::SERVER_MAX_PROTOCOL_VERSION;
+use crate::game_state::GameStreamInterceptors;
 
 static CLIENT_CONTEXT_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 
@@ -277,8 +278,8 @@ pub(crate) async fn make_client_contexts(
         own_positions: pos_send,
         outbound_tx: outbound_tx.clone(),
         next_pos_writeback: Instant::now(),
-
         testonly_farmesh_notify_tx,
+        interceptors: game_state.stream_interceptors.clone(),
     };
     let chunk_sender_0 = MapChunkSender {
         context: context.clone(),
@@ -1540,6 +1541,7 @@ pub(crate) struct InboundWorker {
     next_pos_writeback: Instant,
 
     testonly_farmesh_notify_tx: tokio::sync::watch::Sender<()>,
+    interceptors: Option<Arc<dyn GameStreamInterceptors>>,
 }
 impl InboundWorker {
     fn process_footstep(player: Arc<Player>, ctx: &SharedContext, coord: BlockCoordinate) {
@@ -1623,6 +1625,15 @@ impl InboundWorker {
                             return Ok(());
                         }
                         Ok(Some(message)) => {
+                            if let Some(interceptors) = &self.interceptors {
+                                let player = self.context.player_context.player.clone();
+                                let game_state = self.context.game_state.clone();
+                                if let Err(e) = tokio::task::block_in_place(|| {
+                                    interceptors.handle_message(&message, &game_state, &player)
+                                }) {
+                                    warn!("Stream interceptor error for client {}: {:?}", self.context.id, e);
+                                }
+                            }
                             match run_traced(trace_buffer, async { self.handle_message(&message, &mut step_tx).await }).await {
                                 Ok(_) => {},
                                 Err(e) => {

--- a/perovskite_server/src/server.rs
+++ b/perovskite_server/src/server.rs
@@ -48,7 +48,7 @@ use crate::{
         game_map::timers::{TimerCallback, TimerSettings},
         items::ItemManager,
         mapgen::{FarMeshPoint, MapgenInterface},
-        GameState, GameStateExtension,
+        GameState, GameStateExtension, GameStreamInterceptors,
     },
     media::MediaManager,
     network_server::grpc_service::PerovskiteGameServerImpl,
@@ -288,6 +288,7 @@ pub fn testonly_in_memory_with_db(db: Arc<dyn GameDatabase>) -> Result<Server> {
         0,
         // Force seed to 0 for testing
         Some(0),
+        None,
     )?;
     let bind_address = SocketAddr::new(IpAddr::from_str("::").unwrap(), 0);
     Server::new(runtime, gs, bind_address, LoadedTlsConfig::NoTls)
@@ -363,6 +364,7 @@ pub struct ServerBuilder {
     extensions: type_map::concurrent::TypeMap,
     startup_actions: Vec<Box<dyn FnOnce(&Arc<GameState>) -> Result<()> + Send + Sync + 'static>>,
     force_seed: Option<u32>,
+    pub stream_interceptors: Option<Arc<dyn GameStreamInterceptors>>,
 }
 
 struct DummyMapgen;
@@ -447,6 +449,7 @@ impl ServerBuilder {
             extensions: type_map::concurrent::TypeMap::new(),
             startup_actions: Vec::new(),
             force_seed: None,
+            stream_interceptors: None,
         })
     }
 
@@ -564,6 +567,7 @@ impl ServerBuilder {
             self.extensions,
             startup_counter,
             self.force_seed,
+            self.stream_interceptors,
         )?;
         for (name, settings, callback) in self.map_timers {
             game_state


### PR DESCRIPTION
## Summary
Adds a `GameStreamInterceptors` trait that allows observing and logging all inbound client messages before they are processed by the game server. This enables building record/replay tooling and action logging utilities.

## Key Changes
- **New trait `GameStreamInterceptors`**: Defined in `perovskite_server::game_state` to intercept `StreamToServer` messages with access to game state and the sending player. Runs synchronously before inventory/map locks are taken, suitable for logging and lightweight inspection.

- **Dev server binary**: New `dev_server` entry point that:
  - Starts a game server on a configurable port with an in-memory database
  - Uses a simple flat dirt world instead of complex mapgen for rapid iteration
  - Logs all player actions (dig, tap, place, interact) to timestamped recording files
  - Records player position, facing direction, item slot, and item details for each action

- **Integration points**:
  - `GameState` now holds an optional `stream_interceptors` field
  - `ServerBuilder` accepts stream interceptors during construction
  - `InboundWorker` calls interceptors synchronously before processing each message
  - `GameBuilder::set_stream_interceptors()` allows setting interceptors on test/dev servers

- **API updates**: `GameBuilder::testonly_in_memory()` now accepts an optional port parameter for flexible test server configuration

- **Build configuration**: Added `chrono` dependency and new `dev_server` binary target with `test-support` feature requirement

## Implementation Details
The interceptor hook runs in a `block_in_place` context within the async inbound worker, allowing synchronous I/O operations like file writes without blocking the async runtime. Errors from interceptors are logged as warnings but don't interrupt message processing.

The dev server's action logger formats player positions and angles with configurable rounding (0.25 blocks, 15 degrees) to reduce log noise while maintaining useful spatial information.

https://claude.ai/code/session_01JkpgEzgDcgkNmjPeucqHa4